### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'bundle'
+gem 'bundler'
 gem 'rake'
 gem 'rspec', :require => 'spec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bundle (0.0.1)
-      bundler
     diff-lcs (1.2.5)
     rake (10.4.2)
     rspec (3.3.0)
@@ -23,6 +21,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundle
+  bundler
   rake
   rspec


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock